### PR TITLE
Fix crashes when querying a table with no PK and a JSON col.

### DIFF
--- a/splitgraph/core/fragment_manager.py
+++ b/splitgraph/core/fragment_manager.py
@@ -1158,7 +1158,9 @@ class FragmentManager(MetadataManager):
         to reproduce how PG's ::text works, we give it back the rows and get it to cast them
         to text for us.
         """
-        inner_tuple = "(" + ",".join("%s::" + c.pg_type for c in table.table_schema) + ")"
+        inner_tuple = (
+            "(" + ",".join("%s::" + ct for _, ct in get_change_key(table.table_schema)) + ")"
+        )
         rows = [r for o in object_pks for r in o]
 
         result = []


### PR DESCRIPTION
Make sure we use the "change key" routine when making a surrogate key in order
to not query the values for non-indexable columns (avoid cardinality mismatch).