### PR TITLE
Import Callable from `typing` for Python 3.10 compat

### DIFF
--- a/splitgraph/ingestion/singer/common.py
+++ b/splitgraph/ingestion/singer/common.py
@@ -1,8 +1,7 @@
 import logging
 import traceback
-from collections import Callable
 from functools import wraps
-from typing import Any, Dict, Optional
+from typing import Any, Callable, Dict, Optional
 
 from psycopg2.sql import SQL, Identifier
 


### PR DESCRIPTION
- Python 3.10 no longer provides Callable in collections
- We now import it from typing, to be consistent with previous imports
- See https://docs.python.org/3/whatsnew/3.10.html#pep-612-parameter-specification-variables