### PR TITLE
Add explainer text to `sgr engine add` password prompt

### DIFF
--- a/splitgraph/commandline/engine.py
+++ b/splitgraph/commandline/engine.py
@@ -202,7 +202,9 @@ def _update_bar(
     "--cap-add", help="Add kernel capabilities to the engine container", multiple=True, default=[]
 )
 @click.argument("name", default=DEFAULT_ENGINE)
-@click.password_option()
+@click.password_option(
+    prompt="Enter a password to protect your local engine. \nWill be saved to .sgconfig (usually ~/.splitgraph/.sgconfig)\nPassword"
+)
 def add_engine_c(
     image,
     port,


### PR DESCRIPTION
As an "impatient onboarder" it wasn't immediately obvious to me the implications of `sgr engine add` prompting for a password here.

I actually first thought `sgr` needed root privs to do whatever permission-requiring orchestration it needed to do, and nearly entered my OS password, which would have been persisted in plain text to `.sgconfig`.

I guess it's arguably subjective, but basically the motivation for this PR is that it seemed reasonable to add a bit of explainer text to this prompt, so as to help future users avoid making the same mistake.