### PR TITLE
Use the presence of `cursor_values` for fast path

### DIFF
--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -407,7 +407,7 @@ class ForeignDataWrapperDataSource(MountableDataSource, SyncableDataSource, ABC)
             repository.object_engine.create_schema(staging_schema)
             repository.commit_engines()
 
-            if use_state:
+            if cursor_values:
                 self._mount_and_copy(
                     staging_schema,
                     tables,


### PR DESCRIPTION
If the user presses "Sync" on the UI, we'll still have `use_state=True`, forcing a slow load.