### PR TITLE
Small hack to avoid flash-of-empty-image

### DIFF
--- a/splitgraph/hooks/data_source/base.py
+++ b/splitgraph/hooks/data_source/base.py
@@ -288,13 +288,17 @@ def prepare_new_image(
     hash_or_tag: Optional[str],
     comment: str = "Singer tap ingestion",
     copy_latest: bool = True,
+    use_placeholder_dt: bool = False,
 ) -> Tuple[Optional[Image], str]:
     new_image_hash = "{:064x}".format(getrandbits(256))
     if repository_exists(repository) and copy_latest:
         # Clone the base image and delta compress against it
         base_image: Optional[Image] = repository.images[hash_or_tag] if hash_or_tag else None
         repository.images.add(
-            parent_id=None, image=new_image_hash, comment=comment, created=PLACEHOLDER_DATE
+            parent_id=None,
+            image=new_image_hash,
+            comment=comment,
+            created=PLACEHOLDER_DATE if use_placeholder_dt else None,
         )
         if base_image:
             repository.engine.run_sql(
@@ -311,7 +315,12 @@ def prepare_new_image(
             )
     else:
         base_image = None
-        repository.images.add(parent_id=None, image=new_image_hash, comment=comment)
+        repository.images.add(
+            parent_id=None,
+            image=new_image_hash,
+            comment=comment,
+            created=PLACEHOLDER_DATE if use_placeholder_dt else None,
+        )
     return base_image, new_image_hash
 
 

--- a/splitgraph/hooks/data_source/fdw.py
+++ b/splitgraph/hooks/data_source/fdw.py
@@ -35,6 +35,7 @@ from splitgraph.hooks.data_source.base import (
     MountableDataSource,
     SyncableDataSource,
     get_ingestion_state,
+    make_image_latest,
     prepare_new_image,
 )
 from splitgraph.hooks.data_source.utils import merge_jsonschema
@@ -494,6 +495,7 @@ class ForeignDataWrapperDataSource(MountableDataSource, SyncableDataSource, ABC)
                     )
 
         add_timestamp_tags(repository, new_image_hash)
+        make_image_latest(repository, new_image_hash)
         repository.commit_engines()
 
         return new_image_hash

--- a/splitgraph/ingestion/airbyte/data_source.py
+++ b/splitgraph/ingestion/airbyte/data_source.py
@@ -26,6 +26,7 @@ from splitgraph.engine.postgres.engine import PostgresEngine
 from splitgraph.hooks.data_source.base import (
     SyncableDataSource,
     get_ingestion_state,
+    make_image_latest,
     prepare_new_image,
 )
 from splitgraph.utils.docker import copy_to_container, get_docker_client
@@ -366,6 +367,7 @@ class AirbyteDataSource(SyncableDataSource, ABC):
 
             logging.info("Storing normalized tables")
             _store_processed_airbyte_tables(repository, new_image_hash, staging_schema)
+            make_image_latest(repository, new_image_hash)
             repository.commit_engines()
 
         return new_image_hash

--- a/splitgraph/ingestion/singer/commandline/__init__.py
+++ b/splitgraph/ingestion/singer/commandline/__init__.py
@@ -2,7 +2,7 @@
 import click
 
 from splitgraph.commandline.common import ImageType
-from splitgraph.hooks.data_source.base import prepare_new_image
+from splitgraph.hooks.data_source.base import make_image_latest, prepare_new_image
 
 
 @click.group(name="singer")
@@ -44,6 +44,7 @@ def singer_target(image, delete_old, failure):
     repository, hash_or_tag = image
     base_image, new_image_hash = prepare_new_image(repository, hash_or_tag)
     run_patched_sync(repository, base_image, new_image_hash, delete_old, failure)
+    make_image_latest(repository, new_image_hash)
 
 
 singer_group.add_command(singer_target)

--- a/splitgraph/ingestion/singer/data_source.py
+++ b/splitgraph/ingestion/singer/data_source.py
@@ -15,6 +15,7 @@ from splitgraph.exceptions import DataSourceError
 from splitgraph.hooks.data_source.base import (
     SyncableDataSource,
     get_ingestion_state,
+    make_image_latest,
     prepare_new_image,
 )
 from splitgraph.ingestion.common import add_timestamp_tags
@@ -158,7 +159,7 @@ class SingerDataSource(SyncableDataSource, ABC):
         store_ingestion_state(repository, new_image_hash, state, latest_state)
 
         add_timestamp_tags(repository, new_image_hash)
-
+        make_image_latest(repository, new_image_hash)
         repository.commit_engines()
 
         if failure:

--- a/splitgraph/ingestion/singer/data_source.py
+++ b/splitgraph/ingestion/singer/data_source.py
@@ -15,7 +15,6 @@ from splitgraph.exceptions import DataSourceError
 from splitgraph.hooks.data_source.base import (
     SyncableDataSource,
     get_ingestion_state,
-    make_image_latest,
     prepare_new_image,
 )
 from splitgraph.ingestion.common import add_timestamp_tags
@@ -129,7 +128,9 @@ class SingerDataSource(SyncableDataSource, ABC):
         catalog = self._run_singer_discovery(config)
         catalog = self.build_singer_catalog(catalog, tables)
 
-        base_image, new_image_hash = prepare_new_image(repository, image_hash)
+        base_image, new_image_hash = prepare_new_image(
+            repository, image_hash, use_placeholder_dt=False
+        )
         state = get_ingestion_state(repository, image_hash) if use_state else None
         logging.info("Current ingestion state: %s", state)
 
@@ -159,7 +160,6 @@ class SingerDataSource(SyncableDataSource, ABC):
         store_ingestion_state(repository, new_image_hash, state, latest_state)
 
         add_timestamp_tags(repository, new_image_hash)
-        make_image_latest(repository, new_image_hash)
         repository.commit_engines()
 
         if failure:


### PR DESCRIPTION
When loading data, we create an image and sometimes can commit it to the DB before the loading ends -- which makes that image latest. To work around this, do a two-phase setup: first, set the image's creation time to 1BC, do the ingestion and, if it succeeds, bump it to now() to make the image latest.