### PR TITLE
Write to cstore_fdw tables in multiple queries

### DIFF
--- a/splitgraph/engine/postgres/psycopg.py
+++ b/splitgraph/engine/postgres/psycopg.py
@@ -171,6 +171,9 @@ class PsycopgEngine(SQLEngine):
         """List of notices issued by the server during the previous execution of run_sql."""
         self.notices: List[str] = []
 
+        """The number of rows affected by the last operation (insert/delete/update/fetch)"""
+        self.rowcount: Optional[int] = 0
+
         if conn_params:
             self.conn_params = conn_params
 
@@ -459,6 +462,7 @@ class PsycopgEngine(SQLEngine):
                             # (e.g. to nag them to upgrade etc).
                             for notice in self.notices:
                                 logging.info("%s says: %s", self.name, notice)
+                    self.rowcount = cur.rowcount
                 except Exception as e:
                     # Rollback the transaction (to a savepoint if we're inside the savepoint() context manager)
                     self.rollback()


### PR DESCRIPTION
CStore seems to buffer the result of the full SELECT in an INSERT ... (SELECT ...) in memory. When writing a table into a single chunk, do it in batches of 150k rows (which matches the default CStore stripe length) using DECLARE CURSOR + FETCH. This lets CStore clear out its internal state between queries and keep memory usage low.