### PR TITLE
Add GROUP BY pushdown support to Socrata

### DIFF
--- a/engine/Dockerfile
+++ b/engine/Dockerfile
@@ -188,7 +188,7 @@ COPY ./engine/src/postgres-elasticsearch-fdw/pg_es_fdw /pg_es_fdw/pg_es_fdw
 # Install the Snowflake SQLAlchemy connector
 # Use our fork that supports server-side cursors
 RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \
-    pip install "git+https://github.com/splitgraph/snowflake-sqlalchemy.git@14e64cc0ef7374df0cecc91923ff6901b0d721b7"
+    pip install "git+https://github.com/splitgraph/snowflake-sqlalchemy.git@9e709ca9c8286cec8a789dec5dbbf9460e6652b8"
 
 # Install PyAthena for Amazon Athena SQLAlchemy-based FDW, as well as pandas
 RUN --mount=type=cache,id=pip-cache,target=/root/.cache/pip \


### PR DESCRIPTION
Limited support, notable things that are missing (mostly due to Multicorn):

  - Using functions in `GROUP BYs` (e.g. can't `GROUP BY date_trunc(...)`
  - Upperrel ordering doesn't seem to be pushed down (so `GROUP BY x ORDER BY x DESC LIMIT 1` will still load the result of the whole aggregation in PG
  - Slightly hacky mapping between Socrata result column names and PostgreSQL expected column names (Socrata doesn't support dots, so we give every agg a fake alias and then map it back when it's time to give the rows back to PG).