### PR TITLE
Change ClickHouse Docker repository.

### DIFF
--- a/examples/clickhouse/clickhouse/Dockerfile
+++ b/examples/clickhouse/clickhouse/Dockerfile
@@ -1,4 +1,4 @@
-FROM yandex/clickhouse-server:latest
+FROM clickhouse/clickhouse-server:latest
 
 RUN apt-get update -qq && \
     apt-get install -y odbc-postgresql unixodbc && \


### PR DESCRIPTION
New versions are located in `clickhouse/clickhouse-server` only.