### PR TITLE
Update actions/setup-python in GitHub Actions workflows to v4

### DIFF
--- a/.github/workflows/build_and_test_and_release.yml
+++ b/.github/workflows/build_and_test_and_release.yml
@@ -21,7 +21,7 @@ jobs:
         with:
           submodules: "recursive"
       - name: Setup Python 3.8
-        uses: actions/setup-python@v2
+        uses: actions/setup-python@v4
         with:
           python-version: "3.8"
       - uses: actions/cache@v1
@@ -138,7 +138,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Get artifacts
@@ -167,7 +167,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Get artifacts
@@ -205,7 +205,7 @@ jobs:
     steps:
       - uses: actions/checkout@v1
       - name: Set up Python
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: 3.8
       - name: Get artifacts


### PR DESCRIPTION
Updates the [`actions/setup-python`](https://github.com/actions/setup-python) action used in the GitHub Actions workflow to its newest major version.

Still using v1 or v2 of `actions/setup-python` will generate some warning like in this run: https://github.com/splitgraph/sgr/actions/runs/4600481840

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/checkout@v2, actions/setup-python@v2, actions/cache@v1, actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/setup-python`, because v4 uses Node.js 16.