### PR TITLE
Update actions/upload-artifact in GitHub Actions workflows to v4

### DIFF
--- a/.github/workflows/build_and_test_and_release.yml
+++ b/.github/workflows/build_and_test_and_release.yml
@@ -126,7 +126,7 @@ jobs:
         run: |
           ./.ci/build_wheel.sh
       - name: "Upload release artifacts"
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist
@@ -155,7 +155,7 @@ jobs:
           pyinstaller -F splitgraph.spec
           dist/sgr.exe --version
       - name: Upload binary as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sgr-windows
           path: dist/sgr.exe
@@ -193,7 +193,7 @@ jobs:
           dist/sgr clone --download-all splitgraph/census
           dist/sgr checkout splitgraph/census:latest
       - name: Upload binary as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sgr-linux
           path: dist/sgr
@@ -220,7 +220,7 @@ jobs:
           pyinstaller -F splitgraph.spec
           dist/sgr --version
       - name: Upload single-file binary as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sgr-osx
           path: dist/sgr
@@ -230,7 +230,7 @@ jobs:
           dist/sgr-pkg/sgr --version
           cd dist/sgr-pkg && tar zcvf ../sgr.tgz .
       - name: Upload multi-file binary.gz as artifact
-        uses: actions/upload-artifact@v2
+        uses: actions/upload-artifact@v4
         with:
           name: sgr-osx
           path: dist/sgr.tgz


### PR DESCRIPTION
Updates the [`actions/upload-artifact`](https://github.com/actions/upload-artifact) action used in the GitHub Actions workflow to its newest major version.

Changes in [actions/upload-artifact](https://github.com/actions/upload-artifact):
> ## v3.1.2
> - Update all `@actions/*` NPM packages to their latest versions
> - Update all dev dependencies to their most recent versions
>
> ## v3.1.1
> - Update actions/core package to latest version to remove `set-output` deprecation warning
>
> ## v3.1.0
> - Bump @actions/artifact to v1.1.0
>   - Adds checksum headers on artifact upload
>
> ## v3.0.0
>
> - Update default runtime to node16
> - Update package-lock.json file version to 2

Still using v2 of `actions/upload-artifact` will generate some warning like in this run: https://github.com/splitgraph/sgr/actions/runs/4606051660

> Node.js 12 actions are deprecated. Please update the following actions to use Node.js 16: actions/upload-artifact@v2. For more information see: https://github.blog/changelog/2022-09-22-github-actions-all-actions-will-begin-running-on-node16-instead-of-node12/.

The PR will get rid of those warnings for `actions/upload-artifact`, because v3 uses Node.js 16.