### PR TITLE
build: use lighter `poety-core`

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -93,6 +93,5 @@ exclude = '''
 )/
 '''
 [build-system]
-requires = ["poetry==1.1.6"]
-build-backend = "poetry.masonry.api"
-
+requires = ["poetry-core>=1.0"]
+build-backend = "poetry.core.masonry.api"


### PR DESCRIPTION
I noticed the project is currently using the full `poetry` package as its build backend. There's now a preferred, lightweight `poetry-core` package. From its [readme](https://github.com/python-poetry/poetry-core#why-is-this-required):

> Prior to the release of version `1.1.0`, Poetry was a project management tool that included a PEP 517 build backend. This was inefficient and time consuming when a PEP 517 build was required... This makes PEP 517 builds extremely fast for Poetry managed packages.

This change is especially helpful for distributors (such as Homebrew) to build from source without requiring all of `poetry`.
